### PR TITLE
Extend quic

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,25 @@ Support for WebTransport over HTTP/3 ([draft-ietf-webtrans-http3](https://datatr
 
 Detailed documentation can be found on [quic-go.net](https://quic-go.net/docs/).
 
+## Modifications of this fork
+* Sent timestamp extension.
+* Option to disable packet number skips. **WARNING**: Deactivates ability to detect optimistic acknowledgment attacks.
+* Option to deactivate the congestion controller or only use a pacer. **WARNING**: not negotiated.
+
+`quic.Config` has these new values:
+
+```go
+// What CC to use: Reno, none or pacer only
+CcType CCType
+// What pacer to use: default quic-go pacer or rate based pacer
+PacerType PacerType
+// Disables the packet number skipping of quic. Use with care.
+DisablePnSkips bool
+// Send timestamp frame with each packet.
+SendTimestamps bool
+```
+
+
 ## Projects using quic-go
 
 | Project                                                   | Description                                                                                                                                                       | Stars                                                                                               |

--- a/config.go
+++ b/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/quic-go/quic-go/internal/congestion"
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/quicvarint"
 )
@@ -125,5 +126,20 @@ func populateConfig(config *Config) *Config {
 		EnableStreamResetPartialDelivery: config.EnableStreamResetPartialDelivery,
 		Allow0RTT:                        config.Allow0RTT,
 		Tracer:                           config.Tracer,
+		CcType:                           config.CcType,
+		DisablePnSkips:                   config.DisablePnSkips,
+		SendTimestamps:                   config.SendTimestamps,
+		PacerType:                        config.PacerType,
+		UsePriorityQueue:                 config.UsePriorityQueue,
 	}
+}
+
+func ccToInternalCC(ccType CCType) congestion.InternalccType {
+	toInt := int(ccType)
+	return congestion.InternalccType(toInt)
+}
+
+func pacerToInternalPacer(pacer PacerType) congestion.InternalpacerType {
+	toInt := int(pacer)
+	return congestion.InternalpacerType(toInt)
 }

--- a/config_test.go
+++ b/config_test.go
@@ -128,6 +128,12 @@ func configWithNonZeroNonFunctionFields(t *testing.T) *Config {
 			f.Set(reflect.ValueOf(true))
 		case "EnableStreamResetPartialDelivery":
 			f.Set(reflect.ValueOf(true))
+		case "DisablePnSkips":
+			f.Set(reflect.ValueOf(false))
+		case "SendTimestamps":
+			f.Set(reflect.ValueOf(false))
+		case "CcType":
+			f.Set(reflect.ValueOf(DefaultCC))
 		default:
 			t.Fatalf("all fields must be accounted for, but saw unknown field %q", fn)
 		}

--- a/connection.go
+++ b/connection.go
@@ -321,6 +321,9 @@ var newConnection = func(
 		s.perspective,
 		s.qlogger,
 		s.logger,
+		ccToInternalCC(conf.CcType),
+		s.config.DisablePnSkips,
+		pacerToInternalPacer(conf.PacerType),
 	)
 	s.currentMTUEstimate.Store(uint32(estimateMaxPayloadSize(protocol.ByteCount(s.config.InitialPacketSize))))
 	statelessResetToken := statelessResetter.GetStatelessResetToken(srcConnID)
@@ -368,7 +371,7 @@ var newConnection = func(
 		s.version,
 	)
 	s.cryptoStreamHandler = cs
-	s.packer = newPacketPacker(srcConnID, s.connIDManager.Get, s.initialStream, s.handshakeStream, s.sentPacketHandler, s.retransmissionQueue, cs, s.framer, &s.receivedPacketHandler, s.datagramQueue, s.perspective)
+	s.packer = newPacketPacker(srcConnID, s.connIDManager.Get, s.initialStream, s.handshakeStream, s.sentPacketHandler, s.retransmissionQueue, cs, s.framer, &s.receivedPacketHandler, s.datagramQueue, s.perspective, conf.SendTimestamps)
 	s.unpacker = newPacketUnpacker(cs, s.srcConnIDLen)
 	s.cryptoStreamManager = newCryptoStreamManager(s.initialStream, s.handshakeStream, s.oneRTTStream)
 	return &wrappedConn{Conn: s}
@@ -450,6 +453,9 @@ var newClientConnection = func(
 		s.perspective,
 		s.qlogger,
 		s.logger,
+		ccToInternalCC(conf.CcType),
+		s.config.DisablePnSkips,
+		pacerToInternalPacer(conf.PacerType),
 	)
 	s.currentMTUEstimate.Store(uint32(estimateMaxPayloadSize(protocol.ByteCount(s.config.InitialPacketSize))))
 	oneRTTStream := newCryptoStream()
@@ -494,7 +500,7 @@ var newClientConnection = func(
 	s.cryptoStreamHandler = cs
 	s.cryptoStreamManager = newCryptoStreamManager(s.initialStream, s.handshakeStream, oneRTTStream)
 	s.unpacker = newPacketUnpacker(cs, s.srcConnIDLen)
-	s.packer = newPacketPacker(srcConnID, s.connIDManager.Get, s.initialStream, s.handshakeStream, s.sentPacketHandler, s.retransmissionQueue, cs, s.framer, &s.receivedPacketHandler, s.datagramQueue, s.perspective)
+	s.packer = newPacketPacker(srcConnID, s.connIDManager.Get, s.initialStream, s.handshakeStream, s.sentPacketHandler, s.retransmissionQueue, cs, s.framer, &s.receivedPacketHandler, s.datagramQueue, s.perspective, conf.SendTimestamps)
 	if len(tlsConf.ServerName) > 0 {
 		s.tokenStoreKey = tlsConf.ServerName
 	} else {
@@ -543,7 +549,7 @@ func (c *Conn) preSetup() {
 		uint64(c.config.MaxIncomingUniStreams),
 		c.perspective,
 	)
-	c.framer = newFramer(c.connFlowController)
+	c.framer = newFramer(c.connFlowController, c.config.UsePriorityQueue)
 	c.receivedPackets.Init(8)
 	c.notifyReceivedPacket = make(chan struct{}, 1)
 	c.closeChan = make(chan struct{}, 1)
@@ -1943,6 +1949,8 @@ func (c *Conn) handleFrame(
 		err = c.connIDGenerator.Retire(frame.SequenceNumber, destConnID, rcvTime.Add(3*c.rttStats.PTO(false)))
 	case *wire.HandshakeDoneFrame:
 		err = c.handleHandshakeDoneFrame(rcvTime)
+	case *wire.TimestampFrame:
+		err = c.handleTimestampFrame(frame)
 	default:
 		err = fmt.Errorf("unexpected frame type: %s", reflect.ValueOf(&frame).Elem().Type().Name())
 	}
@@ -2140,10 +2148,17 @@ func (c *Conn) handleDatagramFrame(f *wire.DatagramFrame) error {
 	if f.Length(c.version) > wire.MaxDatagramSize {
 		return &qerr.TransportError{
 			ErrorCode:    qerr.ProtocolViolation,
-			ErrorMessage: "DATAGRAM frame too large",
+			ErrorMessage: fmt.Sprintf("DATAGRAM frame too large; max: %v, actual: %v", wire.MaxDatagramSize, f.Length(c.version)),
 		}
 	}
 	c.datagramQueue.HandleDatagramFrame(f)
+	return nil
+}
+
+func (s *Conn) handleTimestampFrame(_ *wire.TimestampFrame) error {
+	// app gets informed about timestamp in ReceivedShortHeaderPacket tracer
+	// nothing to do here
+
 	return nil
 }
 
@@ -3034,7 +3049,7 @@ func (c *Conn) SendDatagram(p []byte) error {
 		protocol.ByteCount(c.currentMTUEstimate.Load()),
 	)
 	if protocol.ByteCount(len(p)) > maxDataLen {
-		return &DatagramTooLargeError{MaxDatagramPayloadSize: int64(maxDataLen)}
+		return &DatagramTooLargeError{MaxDatagramPayloadSize: int64(maxDataLen), ActualSize: int64(protocol.ByteCount(len(p)))}
 	}
 	f.Data = make([]byte, len(p))
 	copy(f.Data, p)
@@ -3144,4 +3159,8 @@ func (c *Conn) NextConnection(ctx context.Context) (*Conn, error) {
 // connection ID length), and the size of the encryption tag.
 func estimateMaxPayloadSize(mtu protocol.ByteCount) protocol.ByteCount {
 	return mtu - 1 /* type byte */ - 20 /* maximum connection ID length */ - 16 /* tag size */
+}
+
+func (c *Conn) SetPacerRate(rateBytes uint) {
+	c.sentPacketHandler.SetPacerRate(protocol.ByteCount(rateBytes))
 }

--- a/errors.go
+++ b/errors.go
@@ -95,6 +95,7 @@ func (e *StreamError) Error() string {
 // DatagramTooLargeError is returned from Conn.SendDatagram if the payload is too large to be sent.
 type DatagramTooLargeError struct {
 	MaxDatagramPayloadSize int64
+	ActualSize             int64
 }
 
 func (e *DatagramTooLargeError) Is(target error) bool {
@@ -102,4 +103,6 @@ func (e *DatagramTooLargeError) Is(target error) bool {
 	return ok && e.MaxDatagramPayloadSize == t.MaxDatagramPayloadSize
 }
 
-func (e *DatagramTooLargeError) Error() string { return "DATAGRAM frame too large" }
+func (e *DatagramTooLargeError) Error() string {
+	return fmt.Sprintf("DATAGRAM frame too large; max: %v, actual: %v", e.MaxDatagramPayloadSize, e.ActualSize)
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -2,6 +2,7 @@ package quic
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -33,5 +34,6 @@ func TestDatagramTooLargeError(t *testing.T) {
 		&DatagramTooLargeError{MaxDatagramPayloadSize: 1024},
 		&DatagramTooLargeError{MaxDatagramPayloadSize: 1025},
 	))
-	require.Equal(t, "DATAGRAM frame too large", (&DatagramTooLargeError{MaxDatagramPayloadSize: 1024}).Error())
+	errMsg := fmt.Sprintf("DATAGRAM frame too large; max: %v, actual: %v", 1024, 42)
+	require.Equal(t, errMsg, (&DatagramTooLargeError{MaxDatagramPayloadSize: 1024, ActualSize: 42}).Error())
 }

--- a/framer.go
+++ b/framer.go
@@ -1,13 +1,16 @@
 package quic
 
 import (
+	"container/heap"
 	"slices"
 	"sync"
+	"time"
 
 	"github.com/quic-go/quic-go/internal/ackhandler"
 	"github.com/quic-go/quic-go/internal/flowcontrol"
 	"github.com/quic-go/quic-go/internal/monotime"
 	"github.com/quic-go/quic-go/internal/protocol"
+	"github.com/quic-go/quic-go/internal/utils/priorityqueue"
 	"github.com/quic-go/quic-go/internal/utils/ringbuffer"
 	"github.com/quic-go/quic-go/internal/wire"
 	"github.com/quic-go/quic-go/quicvarint"
@@ -24,6 +27,8 @@ const maxStreamControlFrameSize = 25
 
 type streamFrameGetter interface {
 	popStreamFrame(protocol.ByteCount, protocol.Version) (ackhandler.StreamFrame, *wire.StreamDataBlockedFrame, bool)
+	priority() uint32
+	incremental() bool
 }
 
 type streamControlFrameGetter interface {
@@ -34,6 +39,7 @@ type framer struct {
 	mutex sync.Mutex
 
 	activeStreams            map[protocol.StreamID]streamFrameGetter
+	streamPrioQueue          priorityqueue.PriorityQueue
 	streamQueue              ringbuffer.RingBuffer[protocol.StreamID]
 	streamsWithControlFrames map[protocol.StreamID]streamControlFrameGetter
 
@@ -42,19 +48,28 @@ type framer struct {
 	pathResponses              []*wire.PathResponseFrame
 	connFlowController         flowcontrol.ConnectionFlowController
 	queuedTooManyControlFrames bool
+
+	prioQueue bool
 }
 
-func newFramer(connFlowController flowcontrol.ConnectionFlowController) *framer {
+func newFramer(connFlowController flowcontrol.ConnectionFlowController, usePrioQueue bool) *framer {
 	return &framer{
 		activeStreams:            make(map[protocol.StreamID]streamFrameGetter),
 		streamsWithControlFrames: make(map[protocol.StreamID]streamControlFrameGetter),
 		connFlowController:       connFlowController,
+		prioQueue:                usePrioQueue,
 	}
 }
 
 func (f *framer) HasData() bool {
 	f.mutex.Lock()
-	hasData := !f.streamQueue.Empty()
+	var hasData bool
+	if f.prioQueue {
+		hasData = !f.streamPrioQueue.Empty()
+	} else {
+		hasData = !f.streamQueue.Empty()
+	}
+
 	f.mutex.Unlock()
 	if hasData {
 		return true
@@ -101,10 +116,9 @@ func (f *framer) Append(
 	var streamFrameLen protocol.ByteCount
 	f.mutex.Lock()
 	// pop STREAM frames, until less than 128 bytes are left in the packet
-	numActiveStreams := f.streamQueue.Len()
-	for i := 0; i < numActiveStreams; i++ {
+	doIteration := func() bool {
 		if protocol.MinStreamFrameSize > maxLen {
-			break
+			return false
 		}
 		sf, blocked := f.getNextStreamFrame(maxLen, v)
 		if sf.Frame != nil {
@@ -120,11 +134,27 @@ func (f *framer) Append(
 			// In case it doesn't fit, queue it for the next packet.
 			if maxLen < l {
 				f.controlFrames = append(f.controlFrames, blocked)
-				break
+				return false
 			}
 			frames = append(frames, ackhandler.Frame{Frame: blocked})
 			maxLen -= l
 			controlFrameLen += l
+		}
+		return true
+	}
+
+	if f.prioQueue {
+		for !f.streamPrioQueue.Empty() {
+			if !doIteration() {
+				break
+			}
+		}
+	} else {
+		numActiveStreams := f.streamQueue.Len()
+		for i := 0; i < numActiveStreams; i++ {
+			if !doIteration() {
+				break
+			}
 		}
 	}
 
@@ -221,7 +251,15 @@ func (f *framer) QueuedTooManyControlFrames() bool {
 func (f *framer) AddActiveStream(id protocol.StreamID, str streamFrameGetter) {
 	f.mutex.Lock()
 	if _, ok := f.activeStreams[id]; !ok {
-		f.streamQueue.PushBack(id)
+		if f.prioQueue {
+			heap.Push(&f.streamPrioQueue, &priorityqueue.Item{
+				Value:     int64(id),
+				Timestamp: time.Now(),
+				Priority:  int(str.priority()),
+			})
+		} else {
+			f.streamQueue.PushBack(id)
+		}
 		f.activeStreams[id] = str
 	}
 	f.mutex.Unlock()
@@ -246,7 +284,15 @@ func (f *framer) RemoveActiveStream(id protocol.StreamID) {
 }
 
 func (f *framer) getNextStreamFrame(maxLen protocol.ByteCount, v protocol.Version) (ackhandler.StreamFrame, *wire.StreamDataBlockedFrame) {
-	id := f.streamQueue.PopFront()
+	var id protocol.StreamID
+	var item *priorityqueue.Item
+	if f.prioQueue {
+		item = heap.Pop(&f.streamPrioQueue).(*priorityqueue.Item)
+		id = protocol.StreamID(item.Value)
+	} else {
+		id = f.streamQueue.PopFront()
+	}
+
 	// This should never return an error. Better check it anyway.
 	// The stream will only be in the streamQueue, if it enqueued itself there.
 	str, ok := f.activeStreams[id]
@@ -260,7 +306,20 @@ func (f *framer) getNextStreamFrame(maxLen protocol.ByteCount, v protocol.Versio
 	maxLen += protocol.ByteCount(quicvarint.Len(uint64(maxLen)))
 	frame, blocked, hasMoreData := str.popStreamFrame(maxLen, v)
 	if hasMoreData { // put the stream back in the queue (at the end)
-		f.streamQueue.PushBack(id)
+		if f.prioQueue {
+			ts := item.Timestamp
+			if !str.incremental() {
+				ts = time.Now()
+			}
+
+			heap.Push(&f.streamPrioQueue, &priorityqueue.Item{
+				Value:     int64(item.Value),
+				Timestamp: ts,
+				Priority:  int(str.priority()),
+			})
+		} else {
+			f.streamQueue.PushBack(id)
+		}
 	} else { // no more data to send. Stream is not active
 		delete(f.activeStreams, id)
 	}
@@ -275,8 +334,11 @@ func (f *framer) Handle0RTTRejection() {
 	defer f.mutex.Unlock()
 	f.controlFrameMutex.Lock()
 	defer f.controlFrameMutex.Unlock()
-
-	f.streamQueue.Clear()
+	if f.prioQueue {
+		f.streamPrioQueue.Clear()
+	} else {
+		f.streamQueue.Clear()
+	}
 	for id := range f.activeStreams {
 		delete(f.activeStreams, id)
 	}

--- a/interface.go
+++ b/interface.go
@@ -39,6 +39,26 @@ type ClientToken struct {
 	rtt  time.Duration
 }
 
+type CCType int
+
+const (
+	// default cc - Reno
+	DefaultCC CCType = iota
+	// no cc, no pacer
+	DisabledCC
+	// only a pacer, no cc
+	PacerOnly
+)
+
+type PacerType int
+
+const (
+	// default pacer of quic-go
+	DefaultPacer PacerType = iota
+	// a pacer based on the set rate (conn.SetPaceRate)
+	RatePacer
+)
+
 type TokenStore interface {
 	// Pop searches for a ClientToken associated with the given key.
 	// Since tokens are not supposed to be reused, it must remove the token from the cache.
@@ -177,6 +197,16 @@ type Config struct {
 	EnableStreamResetPartialDelivery bool
 
 	Tracer func(ctx context.Context, isClient bool, connID ConnectionID) qlogwriter.Trace
+	// What CC to use: Reno, none or pacer only
+	CcType CCType
+	// What pacer to use: default quic-go pacer or rate based pacer
+	PacerType PacerType
+	// Disables the packet number skipping of quic. Use with care.
+	DisablePnSkips bool
+	// Send timestamp frame with each packet.
+	SendTimestamps bool
+	// Use priority queue for stream scheduling.
+	UsePriorityQueue bool
 }
 
 // ClientInfo contains information about an incoming connection attempt.

--- a/internal/ackhandler/interfaces.go
+++ b/internal/ackhandler/interfaces.go
@@ -36,4 +36,6 @@ type SentPacketHandler interface {
 	OnLossDetectionTimeout(now monotime.Time) error
 
 	MigratedPath(now monotime.Time, initialMaxPacketSize protocol.ByteCount)
+
+	SetPacerRate(protocol.ByteCount)
 }

--- a/internal/ackhandler/sent_packet_handler.go
+++ b/internal/ackhandler/sent_packet_handler.go
@@ -111,6 +111,8 @@ type sentPacketHandler struct {
 	qlogger     qlogwriter.Recorder
 	lastMetrics qlog.MetricsUpdated
 	logger      utils.Logger
+
+	pacerType congestion.InternalpacerType
 }
 
 var _ SentPacketHandler = &sentPacketHandler{}
@@ -128,36 +130,61 @@ func NewSentPacketHandler(
 	pers protocol.Perspective,
 	qlogger qlogwriter.Recorder,
 	logger utils.Logger,
+	ccType congestion.InternalccType,
+	disablePnSkips bool,
+	pacerType congestion.InternalpacerType,
 ) SentPacketHandler {
-	congestion := congestion.NewCubicSender(
-		congestion.DefaultClock{},
-		rttStats,
-		connStats,
-		initialMaxDatagramSize,
-		true, // use Reno
-		qlogger,
-	)
+
+	var cc congestion.SendAlgorithmWithDebugInfos
+
+	switch ccType {
+	case congestion.DefaultCC:
+		cc = congestion.NewCubicSender(
+			congestion.DefaultClock{},
+			rttStats,
+			connStats,
+			initialMaxDatagramSize,
+			true, // use Reno
+			qlogger,
+			pacerType,
+		)
+	case congestion.PacerOnly:
+		cc = congestion.NewPacerOnlySendAlgorithm(congestion.DefaultClock{},
+			rttStats,
+			connStats,
+			initialMaxDatagramSize,
+			qlogger,
+			pacerType,
+		)
+	case congestion.DisabledCC:
+		cc = congestion.NoOpSendAlgorithm{}
+	}
 
 	h := &sentPacketHandler{
 		peerCompletedAddressValidation: pers == protocol.PerspectiveServer,
 		peerAddressValidated:           pers == protocol.PerspectiveClient || clientAddressValidated,
 		initialPackets:                 newPacketNumberSpace(initialPN, false),
 		handshakePackets:               newPacketNumberSpace(0, false),
-		appDataPackets:                 newPacketNumberSpace(0, true),
+		appDataPackets:                 newPacketNumberSpace(0, !disablePnSkips),
 		lostPackets:                    *newLostPacketTracker(64),
 		rttStats:                       rttStats,
 		connStats:                      connStats,
-		congestion:                     congestion,
+		congestion:                     cc,
 		ignorePacketsBelow:             ignorePacketsBelow,
 		perspective:                    pers,
 		qlogger:                        qlogger,
 		logger:                         logger,
+		pacerType:                      pacerType,
 	}
 	if enableECN {
 		h.enableECN = true
 		h.ecnTracker = newECNTracker(logger, qlogger)
 	}
 	return h
+}
+
+func (h *sentPacketHandler) SetPacerRate(rate protocol.ByteCount) {
+	h.congestion.SetPacerRate(rate)
 }
 
 func (h *sentPacketHandler) removeFromBytesInFlight(p *packet) {
@@ -1138,6 +1165,7 @@ func (h *sentPacketHandler) MigratedPath(now monotime.Time, initialMaxDatagramSi
 		initialMaxDatagramSize,
 		true, // use Reno
 		h.qlogger,
+		h.pacerType,
 	)
 	h.setLossDetectionTimer(now)
 }

--- a/internal/ackhandler/sent_packet_handler_test.go
+++ b/internal/ackhandler/sent_packet_handler_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/quic-go/quic-go/internal/congestion"
 	"github.com/quic-go/quic-go/internal/mocks"
 	"github.com/quic-go/quic-go/internal/monotime"
 	"github.com/quic-go/quic-go/internal/protocol"
@@ -119,6 +120,9 @@ func testSentPacketHandlerSendAndAcknowledge(t *testing.T, encLevel protocol.Enc
 		protocol.PerspectiveClient,
 		nil,
 		utils.DefaultLogger,
+		congestion.DefaultCC,
+		false,
+		congestion.DefaultPacer,
 	)
 
 	var packets packetTracker
@@ -174,6 +178,9 @@ func TestSentPacketHandlerAcknowledgeSkippedPacket(t *testing.T) {
 		protocol.PerspectiveClient,
 		nil,
 		utils.DefaultLogger,
+		congestion.DefaultCC,
+		false,
+		congestion.DefaultPacer,
 	)
 
 	now := monotime.Now()
@@ -366,6 +373,9 @@ func testSentPacketHandlerRTTAckDelays(t *testing.T, encLevel protocol.Encryptio
 		protocol.PerspectiveClient,
 		nil,
 		utils.DefaultLogger,
+		congestion.DefaultCC,
+		false,
+		congestion.DefaultPacer,
 	)
 
 	sendPacket := func(t *testing.T, ti monotime.Time) protocol.PacketNumber {
@@ -457,6 +467,9 @@ func testSentPacketHandlerAmplificationLimitServer(t *testing.T, addressValidate
 		protocol.PerspectiveServer,
 		nil,
 		utils.DefaultLogger,
+		congestion.DefaultCC,
+		false,
+		congestion.DefaultPacer,
 	)
 
 	if addressValidated {
@@ -528,6 +541,9 @@ func testSentPacketHandlerAmplificationLimitClient(t *testing.T, dropHandshake b
 		protocol.PerspectiveClient,
 		nil,
 		utils.DefaultLogger,
+		congestion.DefaultCC,
+		false,
+		congestion.DefaultPacer,
 	)
 
 	require.Equal(t, SendAny, sph.SendMode(monotime.Now()))
@@ -584,6 +600,9 @@ func TestSentPacketHandlerDelayBasedLossDetection(t *testing.T) {
 		protocol.PerspectiveServer,
 		nil,
 		utils.DefaultLogger,
+		congestion.DefaultCC,
+		false,
+		congestion.DefaultPacer,
 	)
 
 	var packets packetTracker
@@ -639,6 +658,9 @@ func TestSentPacketHandlerPacketBasedLossDetection(t *testing.T) {
 		protocol.PerspectiveServer,
 		nil,
 		utils.DefaultLogger,
+		congestion.DefaultCC,
+		false,
+		congestion.DefaultPacer,
 	)
 
 	var packets packetTracker
@@ -701,6 +723,9 @@ func testSentPacketHandlerPTO(t *testing.T, encLevel protocol.EncryptionLevel, p
 		protocol.PerspectiveServer,
 		&eventRecorder,
 		utils.DefaultLogger,
+		congestion.DefaultCC,
+		false,
+		congestion.DefaultPacer,
 	)
 
 	// in the application-data packet number space, the PTO is only set
@@ -919,6 +944,9 @@ func TestSentPacketHandlerPacketNumberSpacesPTO(t *testing.T) {
 		protocol.PerspectiveServer,
 		nil,
 		utils.DefaultLogger,
+		congestion.DefaultCC,
+		false,
+		congestion.DefaultPacer,
 	)
 
 	sendPacket := func(t *testing.T, ti monotime.Time, encLevel protocol.EncryptionLevel) protocol.PacketNumber {
@@ -1012,6 +1040,9 @@ func TestSentPacketHandler0RTT(t *testing.T) {
 		protocol.PerspectiveClient,
 		nil,
 		utils.DefaultLogger,
+		congestion.DefaultCC,
+		false,
+		congestion.DefaultPacer,
 	)
 
 	var appDataPackets packetTracker
@@ -1064,6 +1095,9 @@ func TestSentPacketHandlerCongestion(t *testing.T) {
 		protocol.PerspectiveServer,
 		nil,
 		utils.DefaultLogger,
+		congestion.DefaultCC,
+		false,
+		congestion.DefaultPacer,
 	)
 	sph.(*sentPacketHandler).congestion = cong
 
@@ -1165,6 +1199,9 @@ func testSentPacketHandlerRetry(t *testing.T, rtt, expectedRTT time.Duration) {
 		protocol.PerspectiveClient,
 		nil,
 		utils.DefaultLogger,
+		congestion.DefaultCC,
+		false,
+		congestion.DefaultPacer,
 	)
 
 	start := monotime.Now()
@@ -1217,6 +1254,9 @@ func TestSentPacketHandlerRetryAfterPTO(t *testing.T) {
 		protocol.PerspectiveClient,
 		nil,
 		utils.DefaultLogger,
+		congestion.DefaultCC,
+		false,
+		congestion.DefaultPacer,
 	)
 
 	var packets packetTracker
@@ -1262,6 +1302,9 @@ func TestSentPacketHandlerECN(t *testing.T) {
 		protocol.PerspectiveClient,
 		nil,
 		utils.DefaultLogger,
+		congestion.DefaultCC,
+		false,
+		congestion.DefaultPacer,
 	)
 	sph.(*sentPacketHandler).ecnTracker = ecnHandler
 	sph.(*sentPacketHandler).congestion = cong
@@ -1367,6 +1410,9 @@ func TestSentPacketHandlerPathProbe(t *testing.T) {
 		protocol.PerspectiveClient,
 		nil,
 		utils.DefaultLogger,
+		congestion.DefaultCC,
+		false,
+		congestion.DefaultPacer,
 	)
 	sph.DropPackets(protocol.EncryptionInitial, monotime.Now())
 	sph.DropPackets(protocol.EncryptionHandshake, monotime.Now())
@@ -1448,6 +1494,9 @@ func TestSentPacketHandlerPathProbeAckAndLoss(t *testing.T) {
 		protocol.PerspectiveClient,
 		nil,
 		utils.DefaultLogger,
+		congestion.DefaultCC,
+		false,
+		congestion.DefaultPacer,
 	)
 	sph.DropPackets(protocol.EncryptionInitial, monotime.Now())
 	sph.DropPackets(protocol.EncryptionHandshake, monotime.Now())
@@ -1525,6 +1574,9 @@ func testSentPacketHandlerRandomized(t *testing.T, seed uint64) {
 		protocol.PerspectiveClient,
 		nil,
 		utils.DefaultLogger,
+		congestion.DefaultCC,
+		false,
+		congestion.DefaultPacer,
 	)
 	sph.DropPackets(protocol.EncryptionInitial, monotime.Now())
 	sph.DropPackets(protocol.EncryptionHandshake, monotime.Now())
@@ -1595,6 +1647,9 @@ func TestSentPacketHandlerSpuriousLoss(t *testing.T) {
 		protocol.PerspectiveClient,
 		&eventRecorder,
 		utils.DefaultLogger,
+		congestion.DefaultCC,
+		false,
+		congestion.DefaultPacer,
 	)
 
 	var packets packetTracker
@@ -1731,6 +1786,9 @@ func benchmarkSendAndAcknowledge(b *testing.B, ackEvery, inFlight int) {
 		protocol.PerspectiveClient,
 		nil,
 		utils.DefaultLogger,
+		congestion.DefaultCC,
+		false,
+		congestion.DefaultPacer,
 	)
 	now := monotime.Now()
 	sph.DropPackets(protocol.EncryptionInitial, now)

--- a/internal/congestion/cubic_sender_test.go
+++ b/internal/congestion/cubic_sender_test.go
@@ -54,6 +54,7 @@ func newTestCubicSender(cubic bool) *testCubicSender {
 			initialCongestionWindowPackets*maxDatagramSize,
 			MaxCongestionWindow,
 			nil,
+			DefaultPacer,
 		),
 	}
 }
@@ -501,6 +502,7 @@ func TestCubicSenderSlowStartsUpToMaximumCongestionWindow(t *testing.T) {
 		initialCongestionWindowPackets*maxDatagramSize,
 		initialMaxCongestionWindow,
 		nil,
+		DefaultPacer,
 	)
 
 	for i := 1; i < protocol.MaxCongestionWindowPackets; i++ {
@@ -528,6 +530,7 @@ func TestCubicSenderSlowStartsPacketSizeIncrease(t *testing.T) {
 		initialCongestionWindowPackets*maxDatagramSize,
 		initialMaxCongestionWindow,
 		nil,
+		DefaultPacer,
 	)
 	const packetSize = initialMaxDatagramSize + 100
 	sender.SetMaxDatagramSize(packetSize)
@@ -552,6 +555,7 @@ func TestCubicSenderLimitCwndIncreaseInCongestionAvoidance(t *testing.T) {
 		initialCongestionWindowPackets*maxDatagramSize,
 		MaxCongestionWindow,
 		nil,
+		DefaultPacer,
 	)
 	testSender := &testCubicSender{
 		sender:   sender,

--- a/internal/congestion/interface.go
+++ b/internal/congestion/interface.go
@@ -5,6 +5,21 @@ import (
 	"github.com/quic-go/quic-go/internal/protocol"
 )
 
+type InternalccType int
+
+const (
+	DefaultCC InternalccType = iota
+	DisabledCC
+	PacerOnly
+)
+
+type InternalpacerType int
+
+const (
+	DefaultPacer InternalpacerType = iota
+	RatePacer
+)
+
 // A SendAlgorithm performs congestion control
 type SendAlgorithm interface {
 	TimeUntilSend(bytesInFlight protocol.ByteCount) monotime.Time
@@ -16,6 +31,7 @@ type SendAlgorithm interface {
 	OnCongestionEvent(number protocol.PacketNumber, lostBytes protocol.ByteCount, priorInFlight protocol.ByteCount)
 	OnRetransmissionTimeout(packetsRetransmitted bool)
 	SetMaxDatagramSize(protocol.ByteCount)
+	SetPacerRate(protocol.ByteCount)
 }
 
 // A SendAlgorithmWithDebugInfos is a SendAlgorithm that exposes some debug infos
@@ -24,4 +40,12 @@ type SendAlgorithmWithDebugInfos interface {
 	InSlowStart() bool
 	InRecovery() bool
 	GetCongestionWindow() protocol.ByteCount
+}
+
+type PacerInt interface {
+	SentPacket(sendTime monotime.Time, size protocol.ByteCount)
+	Budget(now monotime.Time) protocol.ByteCount
+	SetRate(protocol.ByteCount)
+	SetMaxDatagramSize(s protocol.ByteCount)
+	TimeUntilSend() monotime.Time
 }

--- a/internal/congestion/noop_sender.go
+++ b/internal/congestion/noop_sender.go
@@ -1,0 +1,56 @@
+package congestion
+
+import (
+	"math"
+
+	"github.com/quic-go/quic-go/internal/monotime"
+	"github.com/quic-go/quic-go/internal/protocol"
+)
+
+type NoOpSendAlgorithm struct {
+}
+
+func (n NoOpSendAlgorithm) SetMaxDatagramSize(count protocol.ByteCount) {
+}
+
+func (n NoOpSendAlgorithm) TimeUntilSend(bytesInFlight protocol.ByteCount) monotime.Time {
+	return 0
+}
+
+func (n NoOpSendAlgorithm) HasPacingBudget(_ monotime.Time) bool {
+	return true
+}
+
+func (n NoOpSendAlgorithm) OnPacketSent(sentTime monotime.Time, bytesInFlight protocol.ByteCount, packetNumber protocol.PacketNumber, bytes protocol.ByteCount, isRetransmittable bool) {
+}
+
+func (n NoOpSendAlgorithm) CanSend(bytesInFlight protocol.ByteCount) bool {
+	return true
+}
+
+func (n NoOpSendAlgorithm) MaybeExitSlowStart() {
+}
+
+func (n NoOpSendAlgorithm) OnPacketAcked(number protocol.PacketNumber, ackedBytes protocol.ByteCount, priorInFlight protocol.ByteCount, eventTime monotime.Time) {
+}
+
+func (n NoOpSendAlgorithm) OnCongestionEvent(number protocol.PacketNumber, lostBytes protocol.ByteCount, priorInFlight protocol.ByteCount) {
+}
+
+func (n NoOpSendAlgorithm) OnRetransmissionTimeout(packetsRetransmitted bool) {
+}
+
+func (n NoOpSendAlgorithm) InSlowStart() bool {
+	return false
+}
+
+func (n NoOpSendAlgorithm) InRecovery() bool {
+	return false
+}
+
+func (n NoOpSendAlgorithm) GetCongestionWindow() protocol.ByteCount {
+	return math.MaxInt64
+}
+
+func (c NoOpSendAlgorithm) SetPacerRate(b protocol.ByteCount) {
+}

--- a/internal/congestion/pacer.go
+++ b/internal/congestion/pacer.go
@@ -108,3 +108,7 @@ func (p *pacer) TimeUntilSend() monotime.Time {
 func (p *pacer) SetMaxDatagramSize(s protocol.ByteCount) {
 	p.maxDatagramSize = s
 }
+
+func (p *pacer) SetRate(protocol.ByteCount) {
+	// do nothing
+}

--- a/internal/congestion/pacer_only_sender.go
+++ b/internal/congestion/pacer_only_sender.go
@@ -2,6 +2,7 @@ package congestion
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/quic-go/quic-go/internal/monotime"
 	"github.com/quic-go/quic-go/internal/protocol"
@@ -10,17 +11,7 @@ import (
 	"github.com/quic-go/quic-go/qlogwriter"
 )
 
-const (
-	// maxDatagramSize is the default maximum packet size used in the Linux TCP implementation.
-	// Used in QUIC for congestion window computations in bytes.
-	initialMaxDatagramSize     = protocol.ByteCount(protocol.InitialPacketSize)
-	maxBurstPackets            = 3
-	renoBeta                   = 0.7 // Reno backoff factor.
-	minCongestionWindowPackets = 2
-	initialCongestionWindow    = 32
-)
-
-type cubicSender struct {
+type PacerOnlySendAlgorithm struct {
 	hybridSlowStart HybridSlowStart
 	rttStats        *utils.RTTStats
 	connStats       *utils.ConnectionStats
@@ -62,25 +53,23 @@ type cubicSender struct {
 }
 
 var (
-	_ SendAlgorithm               = &cubicSender{}
-	_ SendAlgorithmWithDebugInfos = &cubicSender{}
+	_ SendAlgorithm               = &PacerOnlySendAlgorithm{}
+	_ SendAlgorithmWithDebugInfos = &PacerOnlySendAlgorithm{}
 )
 
-// NewCubicSender makes a new cubic sender
-func NewCubicSender(
+// NewPacerOnlySendAlgorithm makes a new cubic sender
+func NewPacerOnlySendAlgorithm(
 	clock Clock,
 	rttStats *utils.RTTStats,
 	connStats *utils.ConnectionStats,
 	initialMaxDatagramSize protocol.ByteCount,
-	reno bool,
 	qlogger qlogwriter.Recorder,
 	pacerType InternalpacerType,
-) *cubicSender {
-	return newCubicSender(
+) *PacerOnlySendAlgorithm {
+	return newPacerOnlySendAlgorithm(
 		clock,
 		rttStats,
 		connStats,
-		reno,
 		initialMaxDatagramSize,
 		initialCongestionWindow*initialMaxDatagramSize,
 		protocol.MaxCongestionWindowPackets*initialMaxDatagramSize,
@@ -89,18 +78,17 @@ func NewCubicSender(
 	)
 }
 
-func newCubicSender(
+func newPacerOnlySendAlgorithm(
 	clock Clock,
 	rttStats *utils.RTTStats,
 	connStats *utils.ConnectionStats,
-	reno bool,
 	initialMaxDatagramSize,
 	initialCongestionWindow,
 	initialMaxCongestionWindow protocol.ByteCount,
 	qlogger qlogwriter.Recorder,
 	pacerType InternalpacerType,
-) *cubicSender {
-	c := &cubicSender{
+) *PacerOnlySendAlgorithm {
+	c := &PacerOnlySendAlgorithm{
 		rttStats:                   rttStats,
 		connStats:                  connStats,
 		largestSentPacketNumber:    protocol.InvalidPacketNumber,
@@ -112,7 +100,7 @@ func newCubicSender(
 		slowStartThreshold:         protocol.MaxByteCount,
 		cubic:                      NewCubic(clock),
 		clock:                      clock,
-		reno:                       reno,
+		reno:                       true,
 		qlogger:                    qlogger,
 		maxDatagramSize:            initialMaxDatagramSize,
 	}
@@ -136,23 +124,23 @@ func newCubicSender(
 }
 
 // TimeUntilSend returns when the next packet should be sent.
-func (c *cubicSender) TimeUntilSend(_ protocol.ByteCount) monotime.Time {
+func (c *PacerOnlySendAlgorithm) TimeUntilSend(_ protocol.ByteCount) monotime.Time {
 	return c.pacer.TimeUntilSend()
 }
 
-func (c *cubicSender) HasPacingBudget(now monotime.Time) bool {
+func (c *PacerOnlySendAlgorithm) HasPacingBudget(now monotime.Time) bool {
 	return c.pacer.Budget(now) >= c.maxDatagramSize
 }
 
-func (c *cubicSender) maxCongestionWindow() protocol.ByteCount {
+func (c *PacerOnlySendAlgorithm) maxCongestionWindow() protocol.ByteCount {
 	return c.maxDatagramSize * protocol.MaxCongestionWindowPackets
 }
 
-func (c *cubicSender) minCongestionWindow() protocol.ByteCount {
+func (c *PacerOnlySendAlgorithm) minCongestionWindow() protocol.ByteCount {
 	return c.maxDatagramSize * minCongestionWindowPackets
 }
 
-func (c *cubicSender) OnPacketSent(
+func (c *PacerOnlySendAlgorithm) OnPacketSent(
 	sentTime monotime.Time,
 	_ protocol.ByteCount,
 	packetNumber protocol.PacketNumber,
@@ -167,23 +155,27 @@ func (c *cubicSender) OnPacketSent(
 	c.hybridSlowStart.OnPacketSent(packetNumber)
 }
 
-func (c *cubicSender) CanSend(bytesInFlight protocol.ByteCount) bool {
-	return bytesInFlight < c.GetCongestionWindow()
+func (c *PacerOnlySendAlgorithm) CanSend(bytesInFlight protocol.ByteCount) bool {
+	return true
 }
 
-func (c *cubicSender) InRecovery() bool {
-	return c.largestAckedPacketNumber != protocol.InvalidPacketNumber && c.largestAckedPacketNumber <= c.largestSentAtLastCutback
+func (c *PacerOnlySendAlgorithm) InRecovery() bool {
+	return false
 }
 
-func (c *cubicSender) InSlowStart() bool {
-	return c.GetCongestionWindow() < c.slowStartThreshold
+func (c *PacerOnlySendAlgorithm) InSlowStart() bool {
+	return false
 }
 
-func (c *cubicSender) GetCongestionWindow() protocol.ByteCount {
+func (c *PacerOnlySendAlgorithm) GetCongestionWindow() protocol.ByteCount {
+	return math.MaxInt64
+}
+
+func (c *PacerOnlySendAlgorithm) InternalGetCongestionWindow() protocol.ByteCount {
 	return c.congestionWindow
 }
 
-func (c *cubicSender) MaybeExitSlowStart() {
+func (c *PacerOnlySendAlgorithm) MaybeExitSlowStart() {
 	if c.InSlowStart() &&
 		c.hybridSlowStart.ShouldExitSlowStart(c.rttStats.LatestRTT(), c.rttStats.MinRTT(), c.GetCongestionWindow()/c.maxDatagramSize) {
 		// exit slow start
@@ -192,7 +184,7 @@ func (c *cubicSender) MaybeExitSlowStart() {
 	}
 }
 
-func (c *cubicSender) OnPacketAcked(
+func (c *PacerOnlySendAlgorithm) OnPacketAcked(
 	ackedPacketNumber protocol.PacketNumber,
 	ackedBytes protocol.ByteCount,
 	priorInFlight protocol.ByteCount,
@@ -208,7 +200,7 @@ func (c *cubicSender) OnPacketAcked(
 	}
 }
 
-func (c *cubicSender) OnCongestionEvent(packetNumber protocol.PacketNumber, lostBytes, priorInFlight protocol.ByteCount) {
+func (c *PacerOnlySendAlgorithm) OnCongestionEvent(packetNumber protocol.PacketNumber, lostBytes, priorInFlight protocol.ByteCount) {
 	c.connStats.PacketsLost.Add(1)
 	c.connStats.BytesLost.Add(uint64(lostBytes))
 
@@ -237,7 +229,7 @@ func (c *cubicSender) OnCongestionEvent(packetNumber protocol.PacketNumber, lost
 
 // Called when we receive an ack. Normal TCP tracks how many packets one ack
 // represents, but quic has a separate ack for each packet.
-func (c *cubicSender) maybeIncreaseCwnd(
+func (c *PacerOnlySendAlgorithm) maybeIncreaseCwnd(
 	_ protocol.PacketNumber,
 	ackedBytes protocol.ByteCount,
 	priorInFlight protocol.ByteCount,
@@ -276,7 +268,7 @@ func (c *cubicSender) maybeIncreaseCwnd(
 	}
 }
 
-func (c *cubicSender) isCwndLimited(bytesInFlight protocol.ByteCount) bool {
+func (c *PacerOnlySendAlgorithm) isCwndLimited(bytesInFlight protocol.ByteCount) bool {
 	congestionWindow := c.GetCongestionWindow()
 	if bytesInFlight >= congestionWindow {
 		return true
@@ -287,7 +279,7 @@ func (c *cubicSender) isCwndLimited(bytesInFlight protocol.ByteCount) bool {
 }
 
 // BandwidthEstimate returns the current bandwidth estimate
-func (c *cubicSender) BandwidthEstimate() Bandwidth {
+func (c *PacerOnlySendAlgorithm) BandwidthEstimate() Bandwidth {
 	srtt := c.rttStats.SmoothedRTT()
 	if srtt == 0 {
 		// This should never happen, but if it does, avoid division by zero.
@@ -297,7 +289,7 @@ func (c *cubicSender) BandwidthEstimate() Bandwidth {
 }
 
 // OnRetransmissionTimeout is called on an retransmission timeout
-func (c *cubicSender) OnRetransmissionTimeout(packetsRetransmitted bool) {
+func (c *PacerOnlySendAlgorithm) OnRetransmissionTimeout(packetsRetransmitted bool) {
 	c.largestSentAtLastCutback = protocol.InvalidPacketNumber
 	if !packetsRetransmitted {
 		return
@@ -309,7 +301,7 @@ func (c *cubicSender) OnRetransmissionTimeout(packetsRetransmitted bool) {
 }
 
 // OnConnectionMigration is called when the connection is migrated (?)
-func (c *cubicSender) OnConnectionMigration() {
+func (c *PacerOnlySendAlgorithm) OnConnectionMigration() {
 	c.hybridSlowStart.Restart()
 	c.largestSentPacketNumber = protocol.InvalidPacketNumber
 	c.largestAckedPacketNumber = protocol.InvalidPacketNumber
@@ -321,7 +313,7 @@ func (c *cubicSender) OnConnectionMigration() {
 	c.slowStartThreshold = c.initialMaxCongestionWindow
 }
 
-func (c *cubicSender) maybeQlogStateChange(new qlog.CongestionState) {
+func (c *PacerOnlySendAlgorithm) maybeQlogStateChange(new qlog.CongestionState) {
 	if c.qlogger == nil || new == c.lastState {
 		return
 	}
@@ -329,7 +321,7 @@ func (c *cubicSender) maybeQlogStateChange(new qlog.CongestionState) {
 	c.lastState = new
 }
 
-func (c *cubicSender) SetMaxDatagramSize(s protocol.ByteCount) {
+func (c *PacerOnlySendAlgorithm) SetMaxDatagramSize(s protocol.ByteCount) {
 	if s < c.maxDatagramSize {
 		panic(fmt.Sprintf("congestion BUG: decreased max datagram size from %d to %d", c.maxDatagramSize, s))
 	}
@@ -341,6 +333,6 @@ func (c *cubicSender) SetMaxDatagramSize(s protocol.ByteCount) {
 	c.pacer.SetMaxDatagramSize(s)
 }
 
-func (c *cubicSender) SetPacerRate(b protocol.ByteCount) {
+func (c *PacerOnlySendAlgorithm) SetPacerRate(b protocol.ByteCount) {
 	c.pacer.SetRate(b)
 }

--- a/internal/congestion/rate.go
+++ b/internal/congestion/rate.go
@@ -1,0 +1,428 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package congestion
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/quic-go/quic-go/internal/monotime"
+)
+
+// Limit defines the maximum frequency of some events.
+// Limit is represented as number of events per second.
+// A zero Limit allows no events.
+type Limit float64
+
+// Inf is the infinite rate limit; it allows all events (even if burst is zero).
+const Inf = Limit(math.MaxFloat64)
+
+// Every converts a minimum time interval between events to a Limit.
+func Every(interval time.Duration) Limit {
+	if interval <= 0 {
+		return Inf
+	}
+	return 1 / Limit(interval.Seconds())
+}
+
+// A Limiter controls how frequently events are allowed to happen.
+// It implements a "token bucket" of size b, initially full and refilled
+// at rate r tokens per second.
+// Informally, in any large enough time interval, the Limiter limits the
+// rate to r tokens per second, with a maximum burst size of b events.
+// As a special case, if r == Inf (the infinite rate), b is ignored.
+// See https://en.wikipedia.org/wiki/Token_bucket for more about token buckets.
+//
+// The zero value is a valid Limiter, but it will reject all events.
+// Use NewLimiter to create non-zero Limiters.
+//
+// Limiter has three main methods, Allow, Reserve, and Wait.
+// Most callers should use Wait.
+//
+// Each of the three methods consumes a single token.
+// They differ in their behavior when no token is available.
+// If no token is available, Allow returns false.
+// If no token is available, Reserve returns a reservation for a future token
+// and the amount of time the caller must wait before using it.
+// If no token is available, Wait blocks until one can be obtained
+// or its associated context.Context is canceled.
+//
+// The methods AllowN, ReserveN, and WaitN consume n tokens.
+//
+// Limiter is safe for simultaneous use by multiple goroutines.
+type Limiter struct {
+	mu     sync.Mutex
+	limit  Limit
+	burst  int
+	tokens float64
+	// last is the last time the limiter's tokens field was updated
+	last monotime.Time
+	// lastEvent is the latest time of a rate-limited event (past or future)
+	lastEvent monotime.Time
+}
+
+// Limit returns the maximum overall event rate.
+func (lim *Limiter) Limit() Limit {
+	lim.mu.Lock()
+	defer lim.mu.Unlock()
+	return lim.limit
+}
+
+// Burst returns the maximum burst size. Burst is the maximum number of tokens
+// that can be consumed in a single call to Allow, Reserve, or Wait, so higher
+// Burst values allow more events to happen at once.
+// A zero Burst allows no events, unless limit == Inf.
+func (lim *Limiter) Burst() int {
+	lim.mu.Lock()
+	defer lim.mu.Unlock()
+	return lim.burst
+}
+
+// TokensAt returns the number of tokens available at time t.
+func (lim *Limiter) TokensAt(t monotime.Time) float64 {
+	lim.mu.Lock()
+	tokens := lim.advance(t) // does not mutate lim
+	lim.mu.Unlock()
+	return tokens
+}
+
+// Tokens returns the number of tokens available now.
+func (lim *Limiter) Tokens() float64 {
+	return lim.TokensAt(monotime.Now())
+}
+
+// NewLimiter returns a new Limiter that allows events up to rate r and permits
+// bursts of at most b tokens.
+func NewLimiter(r Limit, b int) *Limiter {
+	return &Limiter{
+		limit:  r,
+		burst:  b,
+		tokens: float64(b),
+	}
+}
+
+// Allow reports whether an event may happen now.
+func (lim *Limiter) Allow() bool {
+	return lim.AllowN(monotime.Now(), 1)
+}
+
+// AllowN reports whether n events may happen at time t.
+// Use this method if you intend to drop / skip events that exceed the rate limit.
+// Otherwise use Reserve or Wait.
+func (lim *Limiter) AllowN(t monotime.Time, n int) bool {
+	return lim.reserveN(t, n, 0).ok
+}
+
+// A Reservation holds information about events that are permitted by a Limiter to happen after a delay.
+// A Reservation may be canceled, which may enable the Limiter to permit additional events.
+type Reservation struct {
+	ok        bool
+	lim       *Limiter
+	tokens    int
+	timeToAct monotime.Time
+	// This is the Limit at reservation time, it can change later.
+	limit Limit
+}
+
+// OK returns whether the limiter can provide the requested number of tokens
+// within the maximum wait time.  If OK is false, Delay returns InfDuration, and
+// Cancel does nothing.
+func (r *Reservation) OK() bool {
+	return r.ok
+}
+
+// Delay is shorthand for DelayFrom(monotime.Now()).
+func (r *Reservation) Delay() time.Duration {
+	return r.DelayFrom(monotime.Now())
+}
+
+// InfDuration is the duration returned by Delay when a Reservation is not OK.
+const InfDuration = time.Duration(math.MaxInt64)
+
+// DelayFrom returns the duration for which the reservation holder must wait
+// before taking the reserved action.  Zero duration means act immediately.
+// InfDuration means the limiter cannot grant the tokens requested in this
+// Reservation within the maximum wait time.
+func (r *Reservation) DelayFrom(t monotime.Time) time.Duration {
+	if !r.ok {
+		return InfDuration
+	}
+	delay := r.timeToAct.Sub(t)
+	if delay < 0 {
+		return 0
+	}
+	return delay
+}
+
+// Cancel is shorthand for CancelAt(monotime.Now()).
+func (r *Reservation) Cancel() {
+	r.CancelAt(monotime.Now())
+}
+
+// CancelAt indicates that the reservation holder will not perform the reserved action
+// and reverses the effects of this Reservation on the rate limit as much as possible,
+// considering that other reservations may have already been made.
+func (r *Reservation) CancelAt(t monotime.Time) {
+	if !r.ok {
+		return
+	}
+
+	r.lim.mu.Lock()
+	defer r.lim.mu.Unlock()
+
+	if r.lim.limit == Inf || r.tokens == 0 || r.timeToAct.Before(t) {
+		return
+	}
+
+	// calculate tokens to restore
+	// The duration between lim.lastEvent and r.timeToAct tells us how many tokens were reserved
+	// after r was obtained. These tokens should not be restored.
+	restoreTokens := float64(r.tokens) - r.limit.tokensFromDuration(r.lim.lastEvent.Sub(r.timeToAct))
+	if restoreTokens <= 0 {
+		return
+	}
+	// advance time to now
+	tokens := r.lim.advance(t)
+	// calculate new number of tokens
+	tokens += restoreTokens
+	if burst := float64(r.lim.burst); tokens > burst {
+		tokens = burst
+	}
+	// update state
+	r.lim.last = t
+	r.lim.tokens = tokens
+	if r.timeToAct.Equal(r.lim.lastEvent) {
+		prevEvent := r.timeToAct.Add(r.limit.durationFromTokens(float64(-r.tokens)))
+		if !prevEvent.Before(t) {
+			r.lim.lastEvent = prevEvent
+		}
+	}
+}
+
+// Reserve is shorthand for ReserveN(monotime.Now(), 1).
+func (lim *Limiter) Reserve() *Reservation {
+	return lim.ReserveN(monotime.Now(), 1)
+}
+
+// ReserveN returns a Reservation that indicates how long the caller must wait before n events happen.
+// The Limiter takes this Reservation into account when allowing future events.
+// The returned Reservation’s OK() method returns false if n exceeds the Limiter's burst size.
+// Usage example:
+//
+//	r := lim.ReserveN(monotime.Now(), 1)
+//	if !r.OK() {
+//	  // Not allowed to act! Did you remember to set lim.burst to be > 0 ?
+//	  return
+//	}
+//	time.Sleep(r.Delay())
+//	Act()
+//
+// Use this method if you wish to wait and slow down in accordance with the rate limit without dropping events.
+// If you need to respect a deadline or cancel the delay, use Wait instead.
+// To drop or skip events exceeding rate limit, use Allow instead.
+func (lim *Limiter) ReserveN(t monotime.Time, n int) *Reservation {
+	r := lim.reserveN(t, n, InfDuration)
+	return &r
+}
+
+// Wait is shorthand for WaitN(ctx, 1).
+func (lim *Limiter) Wait(ctx context.Context) (err error) {
+	return lim.WaitN(ctx, 1)
+}
+
+// WaitN blocks until lim permits n events to happen.
+// It returns an error if n exceeds the Limiter's burst size, the Context is
+// canceled, or the expected wait time exceeds the Context's Deadline.
+// The burst limit is ignored if the rate limit is Inf.
+func (lim *Limiter) WaitN(ctx context.Context, n int) (err error) {
+	// The test code calls lim.wait with a fake timer generator.
+	// This is the real timer generator.
+	newTimer := func(d time.Duration) (<-chan time.Time, func() bool, func()) {
+		timer := time.NewTimer(d)
+		return timer.C, timer.Stop, func() {}
+	}
+
+	return lim.wait(ctx, n, monotime.Now(), newTimer)
+}
+
+// wait is the internal implementation of WaitN.
+func (lim *Limiter) wait(ctx context.Context, n int, t monotime.Time, newTimer func(d time.Duration) (<-chan time.Time, func() bool, func())) error {
+	lim.mu.Lock()
+	burst := lim.burst
+	limit := lim.limit
+	lim.mu.Unlock()
+
+	if n > burst && limit != Inf {
+		return fmt.Errorf("rate: Wait(n=%d) exceeds limiter's burst %d", n, burst)
+	}
+	// Check if ctx is already cancelled
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	// Determine wait limit
+	waitLimit := InfDuration
+	if deadline, ok := ctx.Deadline(); ok {
+		waitLimit = deadline.Sub(t.ToTime())
+	}
+	// Reserve
+	r := lim.reserveN(t, n, waitLimit)
+	if !r.ok {
+		return fmt.Errorf("rate: Wait(n=%d) would exceed context deadline", n)
+	}
+	// Wait if necessary
+	delay := r.DelayFrom(t)
+	if delay == 0 {
+		return nil
+	}
+	ch, stop, advance := newTimer(delay)
+	defer stop()
+	advance() // only has an effect when testing
+	select {
+	case <-ch:
+		// We can proceed.
+		return nil
+	case <-ctx.Done():
+		// Context was canceled before we could proceed.  Cancel the
+		// reservation, which may permit other events to proceed sooner.
+		r.Cancel()
+		return ctx.Err()
+	}
+}
+
+// SetLimit is shorthand for SetLimitAt(monotime.Now(), newLimit).
+func (lim *Limiter) SetLimit(newLimit Limit) {
+	lim.SetLimitAt(monotime.Now(), newLimit)
+}
+
+// SetLimitAt sets a new Limit for the limiter. The new Limit, and Burst, may be violated
+// or underutilized by those which reserved (using Reserve or Wait) but did not yet act
+// before SetLimitAt was called.
+func (lim *Limiter) SetLimitAt(t monotime.Time, newLimit Limit) {
+	lim.mu.Lock()
+	defer lim.mu.Unlock()
+
+	tokens := lim.advance(t)
+
+	lim.last = t
+	lim.tokens = tokens
+	lim.limit = newLimit
+}
+
+// SetBurst is shorthand for SetBurstAt(monotime.Now(), newBurst).
+func (lim *Limiter) SetBurst(newBurst int) {
+	lim.SetBurstAt(monotime.Now(), newBurst)
+}
+
+// SetBurstAt sets a new burst size for the limiter.
+func (lim *Limiter) SetBurstAt(t monotime.Time, newBurst int) {
+	lim.mu.Lock()
+	defer lim.mu.Unlock()
+
+	tokens := lim.advance(t)
+
+	lim.last = t
+	lim.tokens = tokens
+	lim.burst = newBurst
+}
+
+// reserveN is a helper method for AllowN, ReserveN, and WaitN.
+// maxFutureReserve specifies the maximum reservation wait duration allowed.
+// reserveN returns Reservation, not *Reservation, to avoid allocation in AllowN and WaitN.
+func (lim *Limiter) reserveN(t monotime.Time, n int, maxFutureReserve time.Duration) Reservation {
+	lim.mu.Lock()
+	defer lim.mu.Unlock()
+
+	if lim.limit == Inf {
+		return Reservation{
+			ok:        true,
+			lim:       lim,
+			tokens:    n,
+			timeToAct: t,
+		}
+	}
+
+	tokens := lim.advance(t)
+
+	// Calculate the remaining number of tokens resulting from the request.
+	tokens -= float64(n)
+
+	// Calculate the wait duration
+	var waitDuration time.Duration
+	if tokens < 0 {
+		waitDuration = lim.limit.durationFromTokens(-tokens)
+	}
+
+	// Decide result
+	ok := n <= lim.burst && waitDuration <= maxFutureReserve
+
+	// Prepare reservation
+	r := Reservation{
+		ok:    ok,
+		lim:   lim,
+		limit: lim.limit,
+	}
+	if ok {
+		r.tokens = n
+		r.timeToAct = t.Add(waitDuration)
+
+		// Update state
+		lim.last = t
+		lim.tokens = tokens
+		lim.lastEvent = r.timeToAct
+	}
+
+	return r
+}
+
+// advance calculates and returns an updated number of tokens for lim
+// resulting from the passage of time.
+// lim is not changed.
+// advance requires that lim.mu is held.
+func (lim *Limiter) advance(t monotime.Time) (newTokens float64) {
+	last := lim.last
+	if t.Before(last) {
+		last = t
+	}
+
+	// Calculate the new number of tokens, due to time that passed.
+	elapsed := t.Sub(last)
+	delta := lim.limit.tokensFromDuration(elapsed)
+	tokens := lim.tokens + delta
+	if burst := float64(lim.burst); tokens > burst {
+		tokens = burst
+	}
+	return tokens
+}
+
+// durationFromTokens is a unit conversion function from the number of tokens to the duration
+// of time it takes to accumulate them at a rate of limit tokens per second.
+func (limit Limit) durationFromTokens(tokens float64) time.Duration {
+	if limit <= 0 {
+		return InfDuration
+	}
+
+	duration := (tokens / float64(limit)) * float64(time.Second)
+
+	// Cap the duration to the maximum representable int64 value, to avoid overflow.
+	if duration > float64(math.MaxInt64) {
+		return InfDuration
+	}
+
+	return time.Duration(duration)
+}
+
+// tokensFromDuration is a unit conversion function from a time duration to the number of tokens
+// which could be accumulated during that duration at a rate of limit tokens per second.
+func (limit Limit) tokensFromDuration(d time.Duration) float64 {
+	if limit <= 0 {
+		return 0
+	}
+	return d.Seconds() * float64(limit)
+}

--- a/internal/congestion/rate_pacer.go
+++ b/internal/congestion/rate_pacer.go
@@ -1,0 +1,74 @@
+package congestion
+
+import (
+	"github.com/quic-go/quic-go/internal/monotime"
+	"github.com/quic-go/quic-go/internal/protocol"
+)
+
+// The pacer implements a token bucket pacing algorithm.
+type ratePacer struct {
+	limit           *Limiter
+	maxDatagramSize protocol.ByteCount
+}
+
+func newRatePacer() *ratePacer {
+	p := &ratePacer{
+		limit:           NewLimiter(Limit(750_000), 1500*8),
+		maxDatagramSize: initialMaxDatagramSize,
+	}
+	return p
+}
+
+func (p *ratePacer) SentPacket(sendTime monotime.Time, size protocol.ByteCount) {
+	r := p.limit.ReserveN(sendTime, int(size*8))
+	if !r.OK() {
+		r.Cancel()
+	}
+}
+
+func (p *ratePacer) Budget(now monotime.Time) protocol.ByteCount {
+	// the caller of Budget only cares if we can send maxDatagramSize or not
+	r := p.limit.ReserveN(now, int(p.maxDatagramSize*8))
+	if !r.OK() {
+		return 0
+	}
+
+	delay := r.DelayFrom(now)
+	r.CancelAt(now) // don't consume the tokens yet; just checking
+
+	if delay <= 0 {
+		return p.maxDatagramSize // tokens available now
+	}
+
+	return 0 // not enough tokens yet
+}
+
+// TimeUntilSend returns when the next packet should be sent.
+// It returns zero if a packet can be sent immediately.
+func (p *ratePacer) TimeUntilSend() monotime.Time {
+	r := p.limit.ReserveN(monotime.Now(), int(p.maxDatagramSize*8))
+	if !r.OK() {
+		// should not happen (maxDatagram smaller than burst size)
+		return 0
+	}
+
+	delay := r.Delay()
+	r.Cancel() // don't consume the tokens yet; just checking
+
+	if delay <= 0 {
+		return 0 // send immediately
+	}
+	return monotime.Now().Add(delay)
+}
+
+func (p *ratePacer) SetMaxDatagramSize(s protocol.ByteCount) {
+	p.maxDatagramSize = s
+}
+
+func (p *ratePacer) SetRate(r protocol.ByteCount) {
+	rateBits := int(r * 8)
+	p.limit.SetLimit(Limit(rateBits))
+	dynamicBurst := 8 * (float64(rateBits) / 200)
+	burst := max(int(dynamicBurst), int(p.maxDatagramSize*8)) // ensure that burst does not get too small
+	p.limit.SetBurst(burst)
+}

--- a/internal/mocks/congestion.go
+++ b/internal/mocks/congestion.go
@@ -36,6 +36,9 @@ func NewMockSendAlgorithmWithDebugInfos(ctrl *gomock.Controller) *MockSendAlgori
 	return mock
 }
 
+func (c *MockSendAlgorithmWithDebugInfos) SetPacerRate(protocol.ByteCount) {
+}
+
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSendAlgorithmWithDebugInfos) EXPECT() *MockSendAlgorithmWithDebugInfosMockRecorder {
 	return m.recorder

--- a/internal/utils/priorityqueue/priority_queue.go
+++ b/internal/utils/priorityqueue/priority_queue.go
@@ -1,0 +1,60 @@
+package priorityqueue
+
+import (
+	"time"
+)
+
+type Item struct {
+	Value     int64
+	Timestamp time.Time
+	Priority  int
+	index     int
+}
+
+// A PriorityQueue implements heap.Interface and holds Items.
+type PriorityQueue []*Item
+
+func (pq PriorityQueue) Empty() bool {
+	return len(pq) <= 0
+}
+
+func (pq PriorityQueue) Len() int { return len(pq) }
+
+func (pq PriorityQueue) Less(i, j int) bool {
+	if pq[i].Priority > pq[j].Priority {
+		return true
+	}
+	if pq[i].Priority < pq[j].Priority {
+		return false
+	}
+	return pq[i].Timestamp.Before(pq[j].Timestamp)
+}
+
+func (pq PriorityQueue) Swap(i, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+	pq[i].index = i
+	pq[j].index = j
+}
+
+func (pq *PriorityQueue) Push(x any) {
+	n := len(*pq)
+	item := x.(*Item)
+	item.index = n
+	*pq = append(*pq, item)
+}
+
+func (pq *PriorityQueue) Pop() any {
+	old := *pq
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil
+	item.index = -1
+	*pq = old[0 : n-1]
+	return item
+}
+
+func (pq *PriorityQueue) Clear() {
+	for !pq.Empty() {
+		pq.Pop()
+	}
+}

--- a/internal/wire/frame_parser.go
+++ b/internal/wire/frame_parser.go
@@ -53,6 +53,7 @@ func (p *FrameParser) ParseType(b []byte, encLevel protocol.EncryptionLevel) (Fr
 		}
 		ft := FrameType(typ)
 		valid := ft.isValidRFC9000() ||
+			ft == FrameTypeTimestamp ||
 			(p.supportsDatagrams && ft.IsDatagramFrameType()) ||
 			(p.supportsResetStreamAt && ft == FrameTypeResetStreamAt) ||
 			(p.supportsAckFrequency && (ft == FrameTypeAckFrequency || ft == FrameTypeImmediateAck))
@@ -165,6 +166,8 @@ func (p *FrameParser) ParseLessCommonFrame(frameType FrameType, data []byte, v p
 		frame, l, err = parseAckFrequencyFrame(data, v)
 	case FrameTypeImmediateAck:
 		frame = &ImmediateAckFrame{}
+	case FrameTypeTimestamp:
+		frame, l, err = parseTimestampFrame(data, v)
 	default:
 		err = errUnknownFrameType
 	}

--- a/internal/wire/frame_parser_test.go
+++ b/internal/wire/frame_parser_test.go
@@ -335,6 +335,13 @@ func TestFrameParserFrames(t *testing.T) {
 			frameType: FrameTypeImmediateAck,
 			frame:     &ImmediateAckFrame{},
 		},
+		{
+			name:      "TIMESTAMP",
+			frameType: FrameTypeTimestamp,
+			frame: &TimestampFrame{
+				Timestamp: 0x1234567890abcdef,
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/wire/frame_type.go
+++ b/internal/wire/frame_type.go
@@ -38,6 +38,8 @@ const (
 
 	FrameTypeDatagramNoLength   FrameType = 0x30
 	FrameTypeDatagramWithLength FrameType = 0x31
+
+	FrameTypeTimestamp FrameType = 0x32
 )
 
 func (t FrameType) IsStreamFrameType() bool {
@@ -61,7 +63,7 @@ func (t FrameType) isAllowedAtEncLevel(encLevel protocol.EncryptionLevel) bool {
 	switch encLevel {
 	case protocol.EncryptionInitial, protocol.EncryptionHandshake:
 		switch t {
-		case FrameTypeCrypto, FrameTypeAck, FrameTypeAckECN, FrameTypeConnectionClose, FrameTypePing:
+		case FrameTypeCrypto, FrameTypeAck, FrameTypeAckECN, FrameTypeConnectionClose, FrameTypePing, FrameTypeTimestamp:
 			return true
 		default:
 			return false

--- a/internal/wire/timestamp_frame.go
+++ b/internal/wire/timestamp_frame.go
@@ -1,0 +1,40 @@
+package wire
+
+import (
+	"github.com/quic-go/quic-go/internal/protocol"
+	"github.com/quic-go/quic-go/quicvarint"
+)
+
+// An TimestampFrame is a timestamp frame
+type TimestampFrame struct {
+	Timestamp uint64
+}
+
+// parseTimestampFrame reads a timestamp frame
+func parseTimestampFrame(b []byte, _ protocol.Version) (*TimestampFrame, int, error) {
+	frame := &TimestampFrame{}
+
+	// read the timestamp
+	ts, l, err := quicvarint.Parse(b)
+	if err != nil {
+		return nil, l, err
+	}
+	frame.Timestamp = ts
+
+	return frame, l, nil
+}
+
+// Append appends an timestamp frame.
+func (f *TimestampFrame) Append(b []byte, _ protocol.Version) ([]byte, error) {
+	b = quicvarint.Append(b, uint64(FrameTypeTimestamp))
+	b = quicvarint.Append(b, f.Timestamp)
+
+	return b, nil
+}
+
+// Length of a written frame
+func (f *TimestampFrame) Length(_ protocol.Version) protocol.ByteCount {
+	length := 1 + quicvarint.Len(f.Timestamp)
+
+	return protocol.ByteCount(length)
+}

--- a/internal/wire/timestamp_frame_test.go
+++ b/internal/wire/timestamp_frame_test.go
@@ -1,0 +1,39 @@
+package wire
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/quic-go/quic-go/internal/protocol"
+	"github.com/quic-go/quic-go/quicvarint"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseTimestampFrame(t *testing.T) {
+
+	var data []byte
+	// data = append(data, timestampFrameType)       // type
+	data = append(data, encodeVarInt(1234567)...) // timestamp
+	frame, l, err := parseTimestampFrame(data, protocol.Version1)
+
+	require.NoError(t, err)
+
+	require.Equal(t, frame.Timestamp, uint64(1234567))
+	require.Equal(t, len(data), l)
+}
+
+func TestAppendAndParseTimestampFrame(t *testing.T) {
+	f := TimestampFrame{Timestamp: uint64(424242)}
+
+	data, err := f.Append(nil, protocol.Version1)
+	require.NoError(t, err)
+
+	expected := []byte{byte(FrameTypeTimestamp)}
+	expected = append(expected, encodeVarInt(uint64(424242))...)
+	require.Equal(t, data, expected)
+
+	r := bytes.NewReader(data)
+	typ, err := quicvarint.Read(r)
+	require.NoError(t, err)
+	require.Equal(t, typ, uint64(FrameTypeTimestamp))
+}

--- a/packet_packer.go
+++ b/packet_packer.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand/v2"
+	"time"
 
 	"github.com/quic-go/quic-go/internal/ackhandler"
 	"github.com/quic-go/quic-go/internal/handshake"
@@ -135,6 +136,8 @@ type packetPacker struct {
 	rand                rand.Rand
 
 	numNonAckElicitingAcks int
+
+	sendTimestamps bool
 }
 
 var _ packer = &packetPacker{}
@@ -151,6 +154,7 @@ func newPacketPacker(
 	acks ackFrameSource,
 	datagramQueue *datagramQueue,
 	perspective protocol.Perspective,
+	sendTimestamps bool,
 ) *packetPacker {
 	var b [16]byte
 	_, _ = crand.Read(b[:])
@@ -168,6 +172,7 @@ func newPacketPacker(
 		acks:                acks,
 		rand:                *rand.New(rand.NewPCG(binary.BigEndian.Uint64(b[:8]), binary.BigEndian.Uint64(b[8:]))),
 		pnManager:           packetNumberManager,
+		sendTimestamps:      sendTimestamps,
 	}
 }
 
@@ -630,10 +635,20 @@ func (p *packetPacker) composeNextPacket(
 	now monotime.Time,
 	v protocol.Version,
 ) payload {
+	// timestamp frame
+	tsframe := wire.TimestampFrame{Timestamp: uint64(time.Now().UnixMicro())}
+	tsLen := tsframe.Length(v)
+	tsAdded := false
+
 	if onlyAck {
 		if ack := p.acks.GetAckFrame(protocol.Encryption1RTT, now, true); ack != nil {
 			ack.Truncate(maxPayloadSize, v)
-			return payload{ack: ack, length: ack.Length(v)}
+			pl := payload{ack: ack, length: ack.Length(v)}
+			if p.sendTimestamps {
+				pl.frames = append(pl.frames, ackhandler.Frame{Frame: &tsframe})
+				pl.length += tsLen
+			}
+			return pl
 		}
 		return payload{}
 	}
@@ -653,10 +668,17 @@ func (p *packetPacker) composeNextPacket(
 	if p.datagramQueue != nil {
 		if f := p.datagramQueue.Peek(); f != nil {
 			size := f.Length(v)
-			if size <= maxPayloadSize-pl.length { // DATAGRAM frame fits
+			if size <= maxPayloadSize-pl.length-tsLen { // DATAGRAM frame fits
 				pl.frames = append(pl.frames, ackhandler.Frame{Frame: f})
 				pl.length += size
 				p.datagramQueue.Pop()
+
+				if p.sendTimestamps {
+					pl.frames = append(pl.frames, ackhandler.Frame{Frame: &tsframe})
+					pl.length += tsLen
+					tsAdded = true
+				}
+
 			} else if pl.ack == nil {
 				// The DATAGRAM frame doesn't fit, and the packet doesn't contain an ACK.
 				// Discard this frame. There's no point in retrying this in the next packet,
@@ -668,10 +690,20 @@ func (p *packetPacker) composeNextPacket(
 	}
 
 	if pl.ack != nil && !hasData && !hasRetransmission {
+		if p.sendTimestamps && !tsAdded {
+			pl.frames = append(pl.frames, ackhandler.Frame{Frame: &tsframe})
+			pl.length += tsLen
+		}
 		return pl
 	}
 
 	if hasRetransmission {
+		if p.sendTimestamps && !tsAdded && pl.length+tsLen <= maxPayloadSize-pl.length {
+			pl.frames = append(pl.frames, ackhandler.Frame{Frame: &tsframe})
+			pl.length += tsLen
+			tsAdded = true
+		}
+
 		for {
 			remainingLen := maxPayloadSize - pl.length
 			if remainingLen < protocol.MinStreamFrameSize {
@@ -687,10 +719,17 @@ func (p *packetPacker) composeNextPacket(
 	}
 
 	if hasData {
+		// add timestamp first
+		if p.sendTimestamps && !tsAdded && pl.length+tsLen <= maxPayloadSize-pl.length {
+			pl.frames = append(pl.frames, ackhandler.Frame{Frame: &tsframe})
+			pl.length += tsLen
+		}
+
 		var lengthAdded protocol.ByteCount
 		startLen := len(pl.frames)
 		pl.frames, pl.streamFrames, lengthAdded = p.framer.Append(pl.frames, pl.streamFrames, maxPayloadSize-pl.length, now, v)
 		pl.length += lengthAdded
+
 		// add handlers for the control frames that were added
 		for i := startLen; i < len(pl.frames); i++ {
 			if pl.frames[i].Handler != nil {
@@ -700,6 +739,8 @@ func (p *packetPacker) composeNextPacket(
 			case *wire.PathChallengeFrame, *wire.PathResponseFrame:
 				// Path probing is currently not supported, therefore we don't need to set the OnAcked callback yet.
 				// PATH_CHALLENGE and PATH_RESPONSE are never retransmitted.
+			case *wire.TimestampFrame:
+				// Timestamp Frames are never retransmitted.
 			default:
 				// we might be packing a 0-RTT packet, but we need to use the 1-RTT ack handler anyway
 				pl.frames[i].Handler = p.retransmissionQueue.AckHandler(protocol.Encryption1RTT)

--- a/packet_packer_test.go
+++ b/packet_packer_test.go
@@ -67,6 +67,7 @@ func newTestPacketPacker(t *testing.T, mockCtrl *gomock.Controller, pers protoco
 			ackFramer,
 			datagramQueue,
 			pers,
+			false,
 		),
 	}
 }

--- a/qlog/frame.go
+++ b/qlog/frame.go
@@ -52,6 +52,8 @@ type (
 	AckFrequencyFrame = wire.AckFrequencyFrame
 	// An ImmediateAckFrame is an IMMEDIATE_ACK frame.
 	ImmediateAckFrame = wire.ImmediateAckFrame
+	// A TimestampFrame is a TIMESTAMP frame.
+	TimestampFrame = wire.TimestampFrame
 )
 
 type AckRange = wire.AckRange
@@ -133,6 +135,8 @@ func (f Frame) Encode(enc *jsontext.Encoder) error {
 		return encodeAckFrequencyFrame(enc, frame)
 	case *ImmediateAckFrame:
 		return encodeImmediateAckFrame(enc, frame)
+	case *TimestampFrame:
+		return encodeTimestampFrame(enc, frame)
 	default:
 		panic("unknown frame type")
 	}
@@ -476,6 +480,17 @@ func encodeImmediateAckFrame(enc *jsontext.Encoder, _ *ImmediateAckFrame) error 
 	h.WriteToken(jsontext.BeginObject)
 	h.WriteToken(jsontext.String("frame_type"))
 	h.WriteToken(jsontext.String("immediate_ack"))
+	h.WriteToken(jsontext.EndObject)
+	return h.err
+}
+
+func encodeTimestampFrame(enc *jsontext.Encoder, f *TimestampFrame) error {
+	h := encoderHelper{enc: enc}
+	h.WriteToken(jsontext.BeginObject)
+	h.WriteToken(jsontext.String("frame_type"))
+	h.WriteToken(jsontext.String("timestamp"))
+	h.WriteToken(jsontext.String("timestamp"))
+	h.WriteToken(jsontext.Uint(f.Timestamp))
 	h.WriteToken(jsontext.EndObject)
 	return h.err
 }

--- a/qlog/qlog_dir.go
+++ b/qlog/qlog_dir.go
@@ -59,3 +59,21 @@ func defaultConnectionTracerWithSchemas(isClient bool, connID ConnectionID, even
 	go fileSeq.Run()
 	return fileSeq
 }
+
+// DefaultConnectionTracerWithName creates qlog file with a custom name and path
+// pathTOQlog = "path/to/filename.qlog"
+func DefaultConnectionTracerWithName(_ context.Context, isClient bool, connID ConnectionID, pathToQlog string) qlogwriter.Trace {
+	f, err := os.Create(pathToQlog)
+	if err != nil {
+		log.Printf("Failed to create qlog file %s: %s", pathToQlog, err.Error())
+		return nil
+	}
+	fileSeq := qlogwriter.NewConnectionFileSeq(
+		utils.NewBufferedWriteCloser(bufio.NewWriter(f), f),
+		isClient,
+		connID,
+		[]string{EventSchema},
+	)
+	go fileSeq.Run()
+	return fileSeq
+}


### PR DESCRIPTION
## Modifications of this fork
* Sent timestamp extension. _**WARNING**_: not negotiated.
* Option to disable packet number skips. _**WARNING**_: Deactivates ability to detect optimistic acknowledgment attacks.
* Option to deactivate the congestion controller or only use a pacer. 
* Add `qlog.DefaultConnectionTracerWithName` for qlog files with custom names.

`quic.Config` has these new values:

```go
// What CC to use: Reno, none or pacer only
CcType CCType
// What pacer to use: default quic-go pacer or rate based pacer
PacerType PacerType
// Disables the packet number skipping of quic. Use with care.
DisablePnSkips bool
// Send timestamp frame with each packet.
SendTimestamps bool
// Use priority queue for stream scheduling.
UsePriorityQueue bool
```

### Priority scheduling
* Added priority scheduling for streams
* needs to be activated
* SendStreams now have the methods  `SetPriority(p uint32)` and `SetIncremental(b bool)`
  * `SetPriority` sets the priority of the stream
  * `SetIncremental`: Incremantal means that the peer wants the older streams with the same priority first.
  Based on [RFC 9218](https://www.rfc-editor.org/rfc/rfc9218.html#name-incremental).
